### PR TITLE
Feat/8 주문 생성 이벤트 소비 및 결제 생성 로직 구현

### DIFF
--- a/src/main/java/com/pagely/paymentservice/application/dto/command/CreatePaymentCommand.java
+++ b/src/main/java/com/pagely/paymentservice/application/dto/command/CreatePaymentCommand.java
@@ -1,0 +1,10 @@
+package com.pagely.paymentservice.application.dto.command;
+
+import java.util.UUID;
+
+public record CreatePaymentCommand(
+        UUID orderId,
+        UUID buyerId,
+        int price
+) {
+}

--- a/src/main/java/com/pagely/paymentservice/application/service/PaymentCommandService.java
+++ b/src/main/java/com/pagely/paymentservice/application/service/PaymentCommandService.java
@@ -1,0 +1,22 @@
+package com.pagely.paymentservice.application.service;
+
+import com.pagely.paymentservice.application.dto.command.CreatePaymentCommand;
+import com.pagely.paymentservice.domain.model.Payment;
+import com.pagely.paymentservice.domain.repository.PaymentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PaymentCommandService {
+
+    private final PaymentRepository paymentRepository;
+
+    @Transactional
+    public void createPayment(CreatePaymentCommand command) {
+        Payment payment = Payment.create(command.orderId(), command.buyerId(), command.price());
+        paymentRepository.save(payment);
+    }
+}

--- a/src/main/java/com/pagely/paymentservice/domain/model/Payment.java
+++ b/src/main/java/com/pagely/paymentservice/domain/model/Payment.java
@@ -43,7 +43,7 @@ public class Payment extends BaseEntity {
     @Column(name = "status", nullable = false, length = 20)
     private PaymentStatus status;
 
-    @Column(name = "method", nullable = false, length = 20)
+    @Column(name = "method", length = 20)
     private String method;
 
     @Column(name = "pg_provider", length = 20)
@@ -63,4 +63,13 @@ public class Payment extends BaseEntity {
 
     @OneToMany(mappedBy = "payment", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PaymentHistory> histories = new ArrayList<>();
+
+    public static Payment create(UUID orderId, UUID buyerId, int amount) {
+        Payment payment = new Payment();
+        payment.orderId = orderId;
+        payment.buyerId = buyerId;
+        payment.amount = amount;
+        payment.status = PaymentStatus.READY;
+        return payment;
+    }
 }

--- a/src/main/java/com/pagely/paymentservice/domain/model/Payment.java
+++ b/src/main/java/com/pagely/paymentservice/domain/model/Payment.java
@@ -18,6 +18,8 @@ import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 @Entity
 @Table(name = "p_payment")
@@ -40,6 +42,7 @@ public class Payment extends BaseEntity {
     private int amount;
 
     @Enumerated(EnumType.STRING)
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
     @Column(name = "status", nullable = false, length = 20)
     private PaymentStatus status;
 

--- a/src/main/java/com/pagely/paymentservice/domain/model/PaymentHistory.java
+++ b/src/main/java/com/pagely/paymentservice/domain/model/PaymentHistory.java
@@ -31,7 +31,6 @@ public class PaymentHistory extends BaseEntity {
     private UUID id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
     @JoinColumn(name = "payment_id", nullable = false)
     private Payment payment;
 
@@ -41,6 +40,7 @@ public class PaymentHistory extends BaseEntity {
     private PaymentStatus fromStatus;
 
     @Enumerated(EnumType.STRING)
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
     @Column(name = "to_status", nullable = false, length = 20)
     private PaymentStatus toStatus;
 

--- a/src/main/java/com/pagely/paymentservice/domain/model/PaymentHistory.java
+++ b/src/main/java/com/pagely/paymentservice/domain/model/PaymentHistory.java
@@ -16,6 +16,8 @@ import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 @Entity
 @Table(name = "p_payment_history")
@@ -29,10 +31,12 @@ public class PaymentHistory extends BaseEntity {
     private UUID id;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
     @JoinColumn(name = "payment_id", nullable = false)
     private Payment payment;
 
     @Enumerated(EnumType.STRING)
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
     @Column(name = "from_status", nullable = false, length = 20)
     private PaymentStatus fromStatus;
 

--- a/src/main/java/com/pagely/paymentservice/domain/model/PaymentHold.java
+++ b/src/main/java/com/pagely/paymentservice/domain/model/PaymentHold.java
@@ -17,6 +17,8 @@ import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 @Entity
 @Table(name = "p_payment_hold")
@@ -46,6 +48,7 @@ public class PaymentHold extends BaseEntity {
     private int amount;
 
     @Enumerated(EnumType.STRING)
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
     @Column(name = "status", nullable = false, length = 20)
     private PaymentHoldStatus status;
 

--- a/src/main/java/com/pagely/paymentservice/domain/model/Settlement.java
+++ b/src/main/java/com/pagely/paymentservice/domain/model/Settlement.java
@@ -18,6 +18,8 @@ import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 @Entity
 @Table(name = "p_settlement")
@@ -53,6 +55,7 @@ public class Settlement extends BaseEntity {
     private int settledAmount;
 
     @Enumerated(EnumType.STRING)
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
     @Column(name = "status", nullable = false, length = 20)
     private SettlementStatus status;
 

--- a/src/main/java/com/pagely/paymentservice/domain/repository/PaymentRepository.java
+++ b/src/main/java/com/pagely/paymentservice/domain/repository/PaymentRepository.java
@@ -1,0 +1,7 @@
+package com.pagely.paymentservice.domain.repository;
+
+import com.pagely.paymentservice.domain.model.Payment;
+
+public interface PaymentRepository {
+    Payment save(Payment payment);
+}

--- a/src/main/java/com/pagely/paymentservice/infrastructure/messaging/event/OrderCreatedEvent.java
+++ b/src/main/java/com/pagely/paymentservice/infrastructure/messaging/event/OrderCreatedEvent.java
@@ -1,0 +1,20 @@
+package com.pagely.paymentservice.infrastructure.messaging.event;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record OrderCreatedEvent(
+        String eventId,
+        String eventType,
+        String domainType,
+        String domainId,
+        Instant occurredAt,
+        Payload payload
+) {
+    public record Payload(
+            UUID orderId,
+            UUID buyerId,
+            int price
+    ) {
+    }
+}

--- a/src/main/java/com/pagely/paymentservice/infrastructure/messaging/kafka/consumer/KafkaOrderCreatedConsumer.java
+++ b/src/main/java/com/pagely/paymentservice/infrastructure/messaging/kafka/consumer/KafkaOrderCreatedConsumer.java
@@ -1,0 +1,45 @@
+package com.pagely.paymentservice.infrastructure.messaging.kafka.consumer;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pagely.paymentservice.application.dto.command.CreatePaymentCommand;
+import com.pagely.paymentservice.application.service.PaymentCommandService;
+import com.pagely.paymentservice.infrastructure.messaging.event.OrderCreatedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KafkaOrderCreatedConsumer {
+
+    private final PaymentCommandService paymentCommandService;
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(
+            topics = "order-created",
+            groupId = "payment-service"
+    )
+    public void handleOrderCreated(String strEvent) {
+        try {
+            OrderCreatedEvent event = objectMapper.readValue(strEvent, OrderCreatedEvent.class);
+            log.info("[payment] order-created 이벤트 수신: {}", event.domainId());
+
+            CreatePaymentCommand command = new CreatePaymentCommand(
+                    event.payload().orderId(),
+                    event.payload().buyerId(),
+                    event.payload().price()
+            );
+
+            paymentCommandService.createPayment(command);
+        } catch (JsonProcessingException e) {
+            log.error("[payment] order-created 이벤트 역직렬화 실패. message={}", strEvent, e);
+            //TODO: 실패 재처리 로직 필요
+        } catch (Exception e) {
+            log.error("[payment] order-created 처리 실패. message={}", strEvent, e);
+            //TODO: 실패 재처리 로직 필요
+        }
+    }
+}

--- a/src/main/java/com/pagely/paymentservice/infrastructure/persistence/JpaPaymentRepository.java
+++ b/src/main/java/com/pagely/paymentservice/infrastructure/persistence/JpaPaymentRepository.java
@@ -1,0 +1,8 @@
+package com.pagely.paymentservice.infrastructure.persistence;
+
+import com.pagely.paymentservice.domain.model.Payment;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaPaymentRepository extends JpaRepository<Payment, UUID> {
+}

--- a/src/main/java/com/pagely/paymentservice/infrastructure/persistence/PaymentRepositoryAdapter.java
+++ b/src/main/java/com/pagely/paymentservice/infrastructure/persistence/PaymentRepositoryAdapter.java
@@ -1,0 +1,18 @@
+package com.pagely.paymentservice.infrastructure.persistence;
+
+import com.pagely.paymentservice.domain.model.Payment;
+import com.pagely.paymentservice.domain.repository.PaymentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class PaymentRepositoryAdapter implements PaymentRepository {
+
+    private final JpaPaymentRepository jpaPaymentRepository;
+
+    @Override
+    public Payment save(Payment payment) {
+        return jpaPaymentRepository.save(payment);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,6 +26,19 @@ spring:
     locations: classpath:db/migration
     baseline-on-migrate: true
 
+  kafka:
+    bootstrap-servers: localhost:9092
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      properties:
+        spring.json.add.type.headers: false
+    consumer:
+      group-id: payment-service
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+
 logging:
   level:
     org.flywaydb: info

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -36,7 +36,7 @@ CREATE TABLE p_payment
     buyer_id         UUID            NOT NULL,
     amount           INT             NOT NULL,
     status           payment_status  NOT NULL,
-    method           VARCHAR(20)     NOT NULL,
+    method           VARCHAR(20),
     pg_provider      VARCHAR(20),
     payment_key      VARCHAR(200),
     pg_approved_at   TIMESTAMP,


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- 주문 생성 이벤트 소비 및 결제 생성 로직 구현

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #8 
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to #7, #8  

## ✅ 자체 체크리스트 (필수)
- [ ] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [ ] Postman 테스트 완료 (인증샷 첨부)
- [ ] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [ ] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.
- `order-created` 이벤트 payload
<img width="739" height="273" alt="image" src="https://github.com/user-attachments/assets/c80c0a09-5258-44de-b2da-2f2293ebdb09" />

</br>

- `payment-service` consumer
<img width="999" height="315" alt="image" src="https://github.com/user-attachments/assets/c963d5ad-7edd-4ba1-94bc-8eed73403bf7" />

</br>

- Kafka 이벤트 consume 로그
<img width="1552" height="412" alt="image" src="https://github.com/user-attachments/assets/b01f3d57-ec5a-4edc-89c4-b5fd7bd1c2b6" />


## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
> - [ ] 논의점
<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 새로운 기능
- 주문 생성 이벤트 수신 시 자동으로 결제 생성되는 비동기 처리 흐름 추가
- Kafka 기반 메시지 소비로 주문-결제 연동 구현

## Chores
- Kafka 연결 및 직렬화/역직렬화 설정 추가
- 결제 영속화 인프라 및 저장 로직 도입
- 초기 DB 마이그레이션에서 결제 테이블의 특정 컬럼을 nullable로 조정
<!-- end of auto-generated comment: release notes by coderabbit.ai -->