### PR TITLE
Feat/9 Toss 결제 승인 API 연동 및 결과 처리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,7 @@ dependencies {
 
     runtimeOnly 'org.postgresql:postgresql'
 
+    testImplementation 'com.h2database:h2'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/src/main/java/com/pagely/paymentservice/application/dto/command/ConfirmPaymentCommand.java
+++ b/src/main/java/com/pagely/paymentservice/application/dto/command/ConfirmPaymentCommand.java
@@ -1,0 +1,10 @@
+package com.pagely.paymentservice.application.dto.command;
+
+import java.util.UUID;
+
+public record ConfirmPaymentCommand(
+        String paymentKey,
+        UUID orderId,
+        int price
+) {
+}

--- a/src/main/java/com/pagely/paymentservice/application/dto/command/ConfirmPaymentCommand.java
+++ b/src/main/java/com/pagely/paymentservice/application/dto/command/ConfirmPaymentCommand.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 public record ConfirmPaymentCommand(
         String paymentKey,
         UUID orderId,
-        int price
+        int price,
+        UUID buyerId
 ) {
 }

--- a/src/main/java/com/pagely/paymentservice/application/dto/command/CreatePaymentCommand.java
+++ b/src/main/java/com/pagely/paymentservice/application/dto/command/CreatePaymentCommand.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 public record CreatePaymentCommand(
         UUID orderId,
         UUID buyerId,
-        int price
+        int price,
+        UUID sellerId
 ) {
 }

--- a/src/main/java/com/pagely/paymentservice/application/dto/result/ConfirmPaymentResult.java
+++ b/src/main/java/com/pagely/paymentservice/application/dto/result/ConfirmPaymentResult.java
@@ -1,0 +1,34 @@
+package com.pagely.paymentservice.application.dto.result;
+
+import com.pagely.paymentservice.domain.model.Payment;
+import com.pagely.paymentservice.domain.model.PaymentStatus;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record ConfirmPaymentResult(
+        UUID id,
+        UUID orderId,
+        UUID buyerId,
+        UUID sellerId,
+        int amount,
+        PaymentStatus status,
+        String method,
+        String pgProvider,
+        String paymentKey,
+        LocalDateTime pgApprovedAt
+) {
+    public static ConfirmPaymentResult fromEntity(Payment payment) {
+        return new ConfirmPaymentResult(
+                payment.getId(),
+                payment.getOrderId(),
+                payment.getBuyerId(),
+                payment.getSellerId(),
+                payment.getAmount(),
+                payment.getStatus(),
+                payment.getMethod(),
+                payment.getPgProvider(),
+                payment.getPaymentKey(),
+                payment.getPgApprovedAt()
+        );
+    }
+}

--- a/src/main/java/com/pagely/paymentservice/application/dto/result/PaymentProviderConfirmResult.java
+++ b/src/main/java/com/pagely/paymentservice/application/dto/result/PaymentProviderConfirmResult.java
@@ -1,0 +1,12 @@
+package com.pagely.paymentservice.application.dto.result;
+
+import java.time.LocalDateTime;
+
+public record PaymentProviderConfirmResult(
+        String paymentKey,
+        String orderId,
+        int totalAmount,
+        String method,
+        LocalDateTime approvedAt
+) {
+}

--- a/src/main/java/com/pagely/paymentservice/application/port/out/PaymentProvider.java
+++ b/src/main/java/com/pagely/paymentservice/application/port/out/PaymentProvider.java
@@ -1,0 +1,10 @@
+package com.pagely.paymentservice.application.port.out;
+
+import com.pagely.paymentservice.application.dto.result.PaymentProviderConfirmResult;
+
+public interface PaymentProvider {
+
+    PaymentProviderConfirmResult confirm(String paymentKey, String orderId, int price);
+
+    void cancel(String paymentKey);
+}

--- a/src/main/java/com/pagely/paymentservice/application/service/PaymentCommandService.java
+++ b/src/main/java/com/pagely/paymentservice/application/service/PaymentCommandService.java
@@ -16,7 +16,7 @@ public class PaymentCommandService {
 
     @Transactional
     public void createPayment(CreatePaymentCommand command) {
-        Payment payment = Payment.create(command.orderId(), command.buyerId(), command.price());
+        Payment payment = Payment.create(command.orderId(), command.buyerId(), command.sellerId(), command.price());
         paymentRepository.save(payment);
     }
 }

--- a/src/main/java/com/pagely/paymentservice/application/service/PaymentCommandService.java
+++ b/src/main/java/com/pagely/paymentservice/application/service/PaymentCommandService.java
@@ -29,6 +29,7 @@ public class PaymentCommandService {
     public ConfirmPaymentResult confirmPayment(ConfirmPaymentCommand command) {
         Payment payment = paymentRepository.findByOrderId(command.orderId());
 
+        payment.validateBuyer(command.buyerId());
         payment.validateAmount(command.price());
 
         // PG 결제 승인 요청

--- a/src/main/java/com/pagely/paymentservice/application/service/PaymentCommandService.java
+++ b/src/main/java/com/pagely/paymentservice/application/service/PaymentCommandService.java
@@ -1,6 +1,10 @@
 package com.pagely.paymentservice.application.service;
 
+import com.pagely.paymentservice.application.dto.command.ConfirmPaymentCommand;
 import com.pagely.paymentservice.application.dto.command.CreatePaymentCommand;
+import com.pagely.paymentservice.application.dto.result.ConfirmPaymentResult;
+import com.pagely.paymentservice.application.dto.result.PaymentProviderConfirmResult;
+import com.pagely.paymentservice.application.port.out.PaymentProvider;
 import com.pagely.paymentservice.domain.model.Payment;
 import com.pagely.paymentservice.domain.repository.PaymentRepository;
 import lombok.RequiredArgsConstructor;
@@ -13,10 +17,31 @@ import org.springframework.transaction.annotation.Transactional;
 public class PaymentCommandService {
 
     private final PaymentRepository paymentRepository;
+    private final PaymentProvider paymentProvider;
 
     @Transactional
     public void createPayment(CreatePaymentCommand command) {
         Payment payment = Payment.create(command.orderId(), command.buyerId(), command.sellerId(), command.price());
         paymentRepository.save(payment);
+    }
+
+    @Transactional
+    public ConfirmPaymentResult confirmPayment(ConfirmPaymentCommand command) {
+        Payment payment = paymentRepository.findByOrderId(command.orderId());
+
+        payment.validateAmount(command.price());
+
+        // PG 결제 승인 요청
+        PaymentProviderConfirmResult result = paymentProvider.confirm(
+                command.paymentKey(),
+                command.orderId().toString(),
+                command.price()
+        );
+
+        payment.validateConfirmResult(result); // PG 승인 응답값 검증
+
+        payment.confirm(result);
+
+        return ConfirmPaymentResult.fromEntity(payment);
     }
 }

--- a/src/main/java/com/pagely/paymentservice/domain/exception/PaymentErrorCode.java
+++ b/src/main/java/com/pagely/paymentservice/domain/exception/PaymentErrorCode.java
@@ -1,0 +1,35 @@
+package com.pagely.paymentservice.domain.exception;
+
+import com.pagely.common.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum PaymentErrorCode implements ErrorCode {
+    PAYMENT_AMOUNT_MISMATCH("결제 금액 정보가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
+    PAYMENT_ORDER_ID_MISMATCH("결제 주문 ID가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
+    PAYMENT_NOT_FOUND("해당 결제정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatus;
+
+    PaymentErrorCode(String message, HttpStatus httpStatus) {
+        this.code = this.name();
+        this.message = message;
+        this.httpStatus = httpStatus;
+    }
+
+    @Override
+    public String getCode() {
+        return this.code;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return this.httpStatus;
+    }
+}

--- a/src/main/java/com/pagely/paymentservice/domain/exception/PaymentErrorCode.java
+++ b/src/main/java/com/pagely/paymentservice/domain/exception/PaymentErrorCode.java
@@ -7,7 +7,8 @@ public enum PaymentErrorCode implements ErrorCode {
     PAYMENT_BUYER_MISMATCH("결제자 정보가 일치하지 않습니다.", HttpStatus.FORBIDDEN),
     PAYMENT_AMOUNT_MISMATCH("결제 금액 정보가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
     PAYMENT_ORDER_ID_MISMATCH("결제 주문 ID가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
-    PAYMENT_NOT_FOUND("해당 결제정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+    PAYMENT_NOT_FOUND("해당 결제정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    PG_CONFIRM_FAILED("PG 결제 승인에 실패하였습니다.", HttpStatus.BAD_GATEWAY);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/pagely/paymentservice/domain/exception/PaymentErrorCode.java
+++ b/src/main/java/com/pagely/paymentservice/domain/exception/PaymentErrorCode.java
@@ -4,6 +4,7 @@ import com.pagely.common.exception.ErrorCode;
 import org.springframework.http.HttpStatus;
 
 public enum PaymentErrorCode implements ErrorCode {
+    PAYMENT_BUYER_MISMATCH("결제자 정보가 일치하지 않습니다.", HttpStatus.FORBIDDEN),
     PAYMENT_AMOUNT_MISMATCH("결제 금액 정보가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
     PAYMENT_ORDER_ID_MISMATCH("결제 주문 ID가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
     PAYMENT_NOT_FOUND("해당 결제정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);

--- a/src/main/java/com/pagely/paymentservice/domain/model/Payment.java
+++ b/src/main/java/com/pagely/paymentservice/domain/model/Payment.java
@@ -116,4 +116,10 @@ public class Payment extends BaseEntity {
         // 결제 보류금 저장
         this.paymentHold = PaymentHold.create(this);
     }
+
+    public void validateBuyer(UUID userId) {
+        if (!this.buyerId.equals(userId)) {
+            throw new BusinessException(PaymentErrorCode.PAYMENT_BUYER_MISMATCH);
+        }
+    }
 }

--- a/src/main/java/com/pagely/paymentservice/domain/model/Payment.java
+++ b/src/main/java/com/pagely/paymentservice/domain/model/Payment.java
@@ -94,8 +94,12 @@ public class Payment extends BaseEntity {
     }
 
     public void validateConfirmResult(PaymentProviderConfirmResult result) {
+        if (result == null) {
+            throw new BusinessException(PaymentErrorCode.PG_CONFIRM_FAILED);
+        }
+
         UUID orderId = UUID.fromString(result.orderId());
-        
+
         if (!this.orderId.equals(orderId)) {
             throw new BusinessException(PaymentErrorCode.PAYMENT_ORDER_ID_MISMATCH);
         }
@@ -106,6 +110,10 @@ public class Payment extends BaseEntity {
     }
 
     public void confirm(PaymentProviderConfirmResult result) {
+        if (result == null) {
+            throw new BusinessException(PaymentErrorCode.PG_CONFIRM_FAILED);
+        }
+
         PaymentStatus prevStatus = this.status;
         this.status = PaymentStatus.COMPLETED;
         this.method = result.method();

--- a/src/main/java/com/pagely/paymentservice/domain/model/Payment.java
+++ b/src/main/java/com/pagely/paymentservice/domain/model/Payment.java
@@ -38,6 +38,9 @@ public class Payment extends BaseEntity {
     @Column(name = "buyer_id", nullable = false)
     private UUID buyerId;
 
+    @Column(name = "seller_id", nullable = false)
+    private UUID sellerId;
+
     @Column(name = "amount", nullable = false)
     private int amount;
 

--- a/src/main/java/com/pagely/paymentservice/domain/model/Payment.java
+++ b/src/main/java/com/pagely/paymentservice/domain/model/Payment.java
@@ -36,7 +36,7 @@ public class Payment extends BaseEntity {
     @Column(name = "id", nullable = false)
     private UUID id;
 
-    @Column(name = "order_id", nullable = false)
+    @Column(name = "order_id", nullable = false, unique = true)
     private UUID orderId;
 
     @Column(name = "buyer_id", nullable = false)

--- a/src/main/java/com/pagely/paymentservice/domain/model/Payment.java
+++ b/src/main/java/com/pagely/paymentservice/domain/model/Payment.java
@@ -94,7 +94,9 @@ public class Payment extends BaseEntity {
     }
 
     public void validateConfirmResult(PaymentProviderConfirmResult result) {
-        if (!this.orderId.equals(result.orderId())) {
+        UUID orderId = UUID.fromString(result.orderId());
+        
+        if (!this.orderId.equals(orderId)) {
             throw new BusinessException(PaymentErrorCode.PAYMENT_ORDER_ID_MISMATCH);
         }
 

--- a/src/main/java/com/pagely/paymentservice/domain/model/Payment.java
+++ b/src/main/java/com/pagely/paymentservice/domain/model/Payment.java
@@ -1,6 +1,9 @@
 package com.pagely.paymentservice.domain.model;
 
 import com.pagely.common.entity.BaseEntity;
+import com.pagely.common.exception.BusinessException;
+import com.pagely.paymentservice.application.dto.result.PaymentProviderConfirmResult;
+import com.pagely.paymentservice.domain.exception.PaymentErrorCode;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -10,6 +13,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -70,6 +74,9 @@ public class Payment extends BaseEntity {
     @OneToMany(mappedBy = "payment", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PaymentHistory> histories = new ArrayList<>();
 
+    @OneToOne(mappedBy = "payment", cascade = CascadeType.ALL, orphanRemoval = true)
+    private PaymentHold paymentHold;
+
     public static Payment create(UUID orderId, UUID buyerId, UUID sellerId, int amount) {
         Payment payment = new Payment();
         payment.orderId = orderId;
@@ -78,5 +85,35 @@ public class Payment extends BaseEntity {
         payment.amount = amount;
         payment.status = PaymentStatus.READY;
         return payment;
+    }
+
+    public void validateAmount(int amount) {
+        if (this.amount != amount) {
+            throw new BusinessException(PaymentErrorCode.PAYMENT_AMOUNT_MISMATCH);
+        }
+    }
+
+    public void validateConfirmResult(PaymentProviderConfirmResult result) {
+        if (!this.orderId.equals(result.orderId())) {
+            throw new BusinessException(PaymentErrorCode.PAYMENT_ORDER_ID_MISMATCH);
+        }
+
+        if (this.amount != result.totalAmount()) {
+            throw new BusinessException(PaymentErrorCode.PAYMENT_AMOUNT_MISMATCH);
+        }
+    }
+
+    public void confirm(PaymentProviderConfirmResult result) {
+        PaymentStatus prevStatus = this.status;
+        this.status = PaymentStatus.COMPLETED;
+        this.method = result.method();
+        this.paymentKey = result.paymentKey();
+        this.pgApprovedAt = result.approvedAt();
+
+        // 결제 이력 등록
+        this.histories.add(PaymentHistory.of(this, prevStatus, "PG 결제 승인"));
+
+        // 결제 보류금 저장
+        this.paymentHold = PaymentHold.create(this);
     }
 }

--- a/src/main/java/com/pagely/paymentservice/domain/model/Payment.java
+++ b/src/main/java/com/pagely/paymentservice/domain/model/Payment.java
@@ -70,10 +70,11 @@ public class Payment extends BaseEntity {
     @OneToMany(mappedBy = "payment", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PaymentHistory> histories = new ArrayList<>();
 
-    public static Payment create(UUID orderId, UUID buyerId, int amount) {
+    public static Payment create(UUID orderId, UUID buyerId, UUID sellerId, int amount) {
         Payment payment = new Payment();
         payment.orderId = orderId;
         payment.buyerId = buyerId;
+        payment.sellerId = sellerId;
         payment.amount = amount;
         payment.status = PaymentStatus.READY;
         return payment;

--- a/src/main/java/com/pagely/paymentservice/domain/model/PaymentHistory.java
+++ b/src/main/java/com/pagely/paymentservice/domain/model/PaymentHistory.java
@@ -46,4 +46,13 @@ public class PaymentHistory extends BaseEntity {
 
     @Column(name = "reason", length = 200)
     private String reason;
+
+    public static PaymentHistory of(Payment payment, PaymentStatus fromStatus, String reason) {
+        PaymentHistory history = new PaymentHistory();
+        history.payment = payment;
+        history.fromStatus = fromStatus;
+        history.toStatus = payment.getStatus();
+        history.reason = reason;
+        return history;
+    }
 }

--- a/src/main/java/com/pagely/paymentservice/domain/model/PaymentHold.java
+++ b/src/main/java/com/pagely/paymentservice/domain/model/PaymentHold.java
@@ -5,12 +5,11 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -31,7 +30,7 @@ public class PaymentHold extends BaseEntity {
     @Column(name = "id", nullable = false)
     private UUID id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @OneToOne
     @JoinColumn(name = "payment_id", nullable = false)
     private Payment payment;
 
@@ -57,4 +56,16 @@ public class PaymentHold extends BaseEntity {
 
     @Column(name = "settled_at")
     private LocalDateTime settledAt;
+
+    public static PaymentHold create(Payment payment) {
+        PaymentHold paymentHold = new PaymentHold();
+        paymentHold.payment = payment;
+        paymentHold.orderId = payment.getOrderId();
+        paymentHold.sellerId = payment.getSellerId();
+        paymentHold.buyerId = payment.getBuyerId();
+        paymentHold.amount = payment.getAmount();
+        paymentHold.status = PaymentHoldStatus.HOLDING;
+        paymentHold.heldAt = LocalDateTime.now();
+        return paymentHold;
+    }
 }

--- a/src/main/java/com/pagely/paymentservice/domain/repository/PaymentRepository.java
+++ b/src/main/java/com/pagely/paymentservice/domain/repository/PaymentRepository.java
@@ -1,7 +1,10 @@
 package com.pagely.paymentservice.domain.repository;
 
 import com.pagely.paymentservice.domain.model.Payment;
+import java.util.UUID;
 
 public interface PaymentRepository {
     Payment save(Payment payment);
+
+    Payment findByOrderId(UUID orderId);
 }

--- a/src/main/java/com/pagely/paymentservice/infrastructure/client/pg/TossConfirmRequest.java
+++ b/src/main/java/com/pagely/paymentservice/infrastructure/client/pg/TossConfirmRequest.java
@@ -1,0 +1,8 @@
+package com.pagely.paymentservice.infrastructure.client.pg;
+
+public record TossConfirmRequest(
+        String paymentKey,
+        String orderId,
+        int amount
+) {
+}

--- a/src/main/java/com/pagely/paymentservice/infrastructure/client/pg/TossConfirmResponse.java
+++ b/src/main/java/com/pagely/paymentservice/infrastructure/client/pg/TossConfirmResponse.java
@@ -1,0 +1,41 @@
+package com.pagely.paymentservice.infrastructure.client.pg;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.pagely.paymentservice.application.dto.result.PaymentProviderConfirmResult;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record TossConfirmResponse(
+        String paymentKey,
+        String orderId,
+        String orderName,
+        String status,           // DONE, CANCELED, PARTIAL_CANCELED, ABORTED, EXPIRED
+        OffsetDateTime requestedAt,
+        OffsetDateTime approvedAt,
+        int totalAmount,
+        int balanceAmount,
+        String method,           // 카드, 가상계좌, 간편결제 등
+        Card card
+) {
+    public PaymentProviderConfirmResult toResult() {
+        return new PaymentProviderConfirmResult(
+                paymentKey,
+                orderId,
+                totalAmount,
+                method,
+                approvedAt != null
+                        ? approvedAt.atZoneSameInstant(ZoneId.of("Asia/Seoul")).toLocalDateTime()
+                        : null
+        );
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Card(
+            String number,
+            String company,
+            String installmentPlanMonths,
+            boolean isInterestFree
+    ) {
+    }
+}

--- a/src/main/java/com/pagely/paymentservice/infrastructure/client/pg/TossPaymentClient.java
+++ b/src/main/java/com/pagely/paymentservice/infrastructure/client/pg/TossPaymentClient.java
@@ -1,0 +1,16 @@
+package com.pagely.paymentservice.infrastructure.client.pg;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(
+        name = "toss",
+        url = "${toss.base-url}",
+        configuration = TossPaymentFeignConfig.class
+)
+public interface TossPaymentClient {
+
+    @PostMapping("/v1/payments/confirm")
+    TossConfirmResponse confirm(@RequestBody TossConfirmRequest request);
+}

--- a/src/main/java/com/pagely/paymentservice/infrastructure/client/pg/TossPaymentFeignConfig.java
+++ b/src/main/java/com/pagely/paymentservice/infrastructure/client/pg/TossPaymentFeignConfig.java
@@ -1,0 +1,20 @@
+package com.pagely.paymentservice.infrastructure.client.pg;
+
+import feign.RequestInterceptor;
+import java.util.Base64;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+
+public class TossPaymentFeignConfig {
+
+    @Value("${toss.secret-key}")
+    private String secretKey;
+
+    @Bean
+    public RequestInterceptor tossAuthInterceptor() {
+        return requestTemplate -> {
+            String encoded = Base64.getEncoder().encodeToString((secretKey + ":").getBytes());
+            requestTemplate.header("Authorization", "Basic " + encoded);
+        };
+    }
+}

--- a/src/main/java/com/pagely/paymentservice/infrastructure/messaging/event/OrderCreatedEvent.java
+++ b/src/main/java/com/pagely/paymentservice/infrastructure/messaging/event/OrderCreatedEvent.java
@@ -14,7 +14,8 @@ public record OrderCreatedEvent(
     public record Payload(
             UUID orderId,
             UUID buyerId,
-            int price
+            int price,
+            UUID sellerId
     ) {
     }
 }

--- a/src/main/java/com/pagely/paymentservice/infrastructure/messaging/kafka/consumer/KafkaOrderCreatedConsumer.java
+++ b/src/main/java/com/pagely/paymentservice/infrastructure/messaging/kafka/consumer/KafkaOrderCreatedConsumer.java
@@ -30,7 +30,8 @@ public class KafkaOrderCreatedConsumer {
             CreatePaymentCommand command = new CreatePaymentCommand(
                     event.payload().orderId(),
                     event.payload().buyerId(),
-                    event.payload().price()
+                    event.payload().price(),
+                    event.payload().sellerId()
             );
 
             paymentCommandService.createPayment(command);

--- a/src/main/java/com/pagely/paymentservice/infrastructure/persistence/JpaPaymentRepository.java
+++ b/src/main/java/com/pagely/paymentservice/infrastructure/persistence/JpaPaymentRepository.java
@@ -5,4 +5,5 @@ import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface JpaPaymentRepository extends JpaRepository<Payment, UUID> {
+    Payment findByOrderId(UUID orderId);
 }

--- a/src/main/java/com/pagely/paymentservice/infrastructure/persistence/PaymentRepositoryAdapter.java
+++ b/src/main/java/com/pagely/paymentservice/infrastructure/persistence/PaymentRepositoryAdapter.java
@@ -2,6 +2,7 @@ package com.pagely.paymentservice.infrastructure.persistence;
 
 import com.pagely.paymentservice.domain.model.Payment;
 import com.pagely.paymentservice.domain.repository.PaymentRepository;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -14,5 +15,10 @@ public class PaymentRepositoryAdapter implements PaymentRepository {
     @Override
     public Payment save(Payment payment) {
         return jpaPaymentRepository.save(payment);
+    }
+
+    @Override
+    public Payment findByOrderId(UUID orderId) {
+        return jpaPaymentRepository.findByOrderId(orderId);
     }
 }

--- a/src/main/java/com/pagely/paymentservice/infrastructure/provider/TossPaymentProviderAdaptor.java
+++ b/src/main/java/com/pagely/paymentservice/infrastructure/provider/TossPaymentProviderAdaptor.java
@@ -1,0 +1,32 @@
+package com.pagely.paymentservice.infrastructure.provider;
+
+import com.pagely.paymentservice.application.dto.result.PaymentProviderConfirmResult;
+import com.pagely.paymentservice.application.port.out.PaymentProvider;
+import com.pagely.paymentservice.infrastructure.client.pg.TossConfirmRequest;
+import com.pagely.paymentservice.infrastructure.client.pg.TossConfirmResponse;
+import com.pagely.paymentservice.infrastructure.client.pg.TossPaymentClient;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TossPaymentProviderAdaptor implements PaymentProvider {
+
+    private final TossPaymentClient tossPaymentClient;
+
+    @Override
+    public PaymentProviderConfirmResult confirm(String paymentKey, String orderId, int amount) {
+        TossConfirmRequest requestBody = new TossConfirmRequest(paymentKey, orderId, amount);
+
+        TossConfirmResponse response = tossPaymentClient.confirm(requestBody);
+        log.info("[Toss 결제 승인 response={}", response);
+        return response.toResult();
+    }
+
+    @Override
+    public void cancel(String paymentKey) {
+
+    }
+}

--- a/src/main/java/com/pagely/paymentservice/presentation/controller/PaymentController.java
+++ b/src/main/java/com/pagely/paymentservice/presentation/controller/PaymentController.java
@@ -1,0 +1,36 @@
+package com.pagely.paymentservice.presentation.controller;
+
+import com.pagely.common.auth.Role;
+import com.pagely.common.auth.annotation.AuthRequired;
+import com.pagely.common.auth.annotation.CurrentUserId;
+import com.pagely.common.response.ApiResponse;
+import com.pagely.paymentservice.application.dto.result.ConfirmPaymentResult;
+import com.pagely.paymentservice.application.service.PaymentCommandService;
+import com.pagely.paymentservice.presentation.dto.request.ConfirmPaymentRequest;
+import com.pagely.paymentservice.presentation.dto.response.ConfirmPaymentResponse;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/payments")
+@RequiredArgsConstructor
+public class PaymentController {
+
+    private final PaymentCommandService paymentCommandService;
+
+    @PostMapping("/confirm")
+    @AuthRequired(role = Role.USER)
+    public ResponseEntity<ApiResponse> confirmPayment(
+            @CurrentUserId UUID userId,
+            @Valid @RequestBody ConfirmPaymentRequest request
+    ) {
+        ConfirmPaymentResult result = paymentCommandService.confirmPayment(request.toCommand(userId));
+        return ApiResponse.ok(ConfirmPaymentResponse.fromResult(result));
+    }
+}

--- a/src/main/java/com/pagely/paymentservice/presentation/dto/request/ConfirmPaymentRequest.java
+++ b/src/main/java/com/pagely/paymentservice/presentation/dto/request/ConfirmPaymentRequest.java
@@ -1,0 +1,28 @@
+package com.pagely.paymentservice.presentation.dto.request;
+
+import com.pagely.paymentservice.application.dto.command.ConfirmPaymentCommand;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+
+public record ConfirmPaymentRequest(
+        @NotBlank(message = "paymentKey는 필수입니다.")
+        String paymentKey,
+
+        @NotNull(message = "orderId는 필수입니다.")
+        UUID orderId,
+
+        @NotNull(message = "amount는 필수입니다.")
+        @Min(value = 0, message = "amount는 0 이상이어야 합니다.")
+        Integer amount
+) {
+    public ConfirmPaymentCommand toCommand(UUID userId) {
+        return new ConfirmPaymentCommand(
+                this.paymentKey,
+                this.orderId,
+                this.amount,
+                userId
+        );
+    }
+}

--- a/src/main/java/com/pagely/paymentservice/presentation/dto/response/ConfirmPaymentResponse.java
+++ b/src/main/java/com/pagely/paymentservice/presentation/dto/response/ConfirmPaymentResponse.java
@@ -1,0 +1,34 @@
+package com.pagely.paymentservice.presentation.dto.response;
+
+import com.pagely.paymentservice.application.dto.result.ConfirmPaymentResult;
+import com.pagely.paymentservice.domain.model.PaymentStatus;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record ConfirmPaymentResponse(
+        UUID id,
+        UUID orderId,
+        UUID buyerId,
+        UUID sellerId,
+        int amount,
+        PaymentStatus status,
+        String method,
+        String pgProvider,
+        String paymentKey,
+        LocalDateTime pgApprovedAt
+) {
+    public static ConfirmPaymentResponse fromResult(ConfirmPaymentResult result) {
+        return new ConfirmPaymentResponse(
+                result.id(),
+                result.orderId(),
+                result.buyerId(),
+                result.sellerId(),
+                result.amount(),
+                result.status(),
+                result.method(),
+                result.pgProvider(),
+                result.paymentKey(),
+                result.pgApprovedAt()
+        );
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -51,3 +51,7 @@ eureka:
     enabled: false
     register-with-eureka: false
     fetch-registry: false
+
+toss:
+  base-url: ${TOSS_API_BASE_URL}
+  secret-key: ${TOSS_SECRET_KEY}

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -34,6 +34,7 @@ CREATE TABLE p_payment
     id               UUID            NOT NULL,
     order_id         UUID            NOT NULL,
     buyer_id         UUID            NOT NULL,
+    seller_id        UUID            NOT NULL,
     amount           INT             NOT NULL,
     status           payment_status  NOT NULL,
     method           VARCHAR(20),
@@ -55,6 +56,7 @@ COMMENT ON TABLE  p_payment                 IS '결제';
 COMMENT ON COLUMN p_payment.id              IS '결제 ID';
 COMMENT ON COLUMN p_payment.order_id        IS '주문 ID';
 COMMENT ON COLUMN p_payment.buyer_id        IS '구매자 ID';
+COMMENT ON COLUMN p_payment.seller_id       IS '판매자 ID';
 COMMENT ON COLUMN p_payment.amount          IS '결제 금액';
 COMMENT ON COLUMN p_payment.status          IS '결제 상태';
 COMMENT ON COLUMN p_payment.method          IS '결제 수단 CARD/POINT';

--- a/src/main/resources/db/migration/V2__add_unique_order_id.sql
+++ b/src/main/resources/db/migration/V2__add_unique_order_id.sql
@@ -1,0 +1,2 @@
+ALTER TABLE p_payment
+    ADD CONSTRAINT uq_payment_order_id UNIQUE (order_id);

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -1,0 +1,3 @@
+toss:
+  base-url: https://api.tosspayments.com
+  secret-key: test-secret-key

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -1,3 +1,0 @@
-toss:
-  base-url: https://api.tosspayments.com
-  secret-key: test-secret-key

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -6,7 +6,7 @@ spring:
     password:
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: none
     database-platform: org.hibernate.dialect.H2Dialect
   flyway:
     enabled: false

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,16 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=PostgreSQL
+    driver-class-name: org.h2.Driver
+    username: test
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    database-platform: org.hibernate.dialect.H2Dialect
+  flyway:
+    enabled: false
+
+toss:
+  base-url: https://api.tosspayments.com
+  secret-key: test-secret-key


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- #9 
- TOSS 결제 승인 API 연동 및 승인 요청 로직 구현
- FeignClient를 사용하여 외부 결제 API 호출 구조 구성
- 결제 승인 응답 데이터를 기반으로 결제 보류금 생성 처리
- 결제(`p_payment`)테이블에 `seller_id` 컬럼 추가 (`V1__init.sql` 수정)

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #9  \
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to #9

## ✅ 자체 체크리스트 (필수)
- [ ] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [ ] Postman 테스트 완료 (인증샷 첨부)
- [ ] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [ ] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.

## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
> - [ ] 논의점
<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 결제 확인 API 추가: POST /api/v1/payments/confirm
  * 외부 PG 연동을 통한 결제 확인 처리 도입
  * 결제에 판매자 정보(sellerId) 저장 및 반환 추가
  * 결제 상태 변경 시 이력 기록 및 결제 보유(PaymentHold) 생성 지원

* **기타(설정·마이그레이션)**
  * PG 관련 설정 추가 및 DB 마이그레이션(판매자 컬럼·order_id 유니크) 적용
<!-- end of auto-generated comment: release notes by coderabbit.ai -->